### PR TITLE
parseOption gets called at least twice, therefore deleting vars will force default settings after 1st call

### DIFF
--- a/connect.js
+++ b/connect.js
@@ -68,8 +68,6 @@ var parseOptions = function(options){
 		port: +options.port || (options.secure?6697:6667)
 	}
 	if(options.secure && options.lazyCA) options.connection.rejectUnauthorized = false
-	delete(options.host)
-	delete(options.port)
 	return options
 }
 


### PR DESCRIPTION
couldnt get the example to work without doing this fix
